### PR TITLE
Update urls for target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 
 compile:
 	mkdir $(TEMP) || true
-	curl -O -z libpng-$(VERSION).tar.xz http://kent.dl.sourceforge.net/project/libpng/$(PACKAGE)/$(VERSION)/libpng-$(VERSION).tar.xz
+	curl -O -z libpng-$(VERSION).tar.xz http://iweb.dl.sourceforge.net/project/libpng/$(PACKAGE)/$(VERSION)/libpng-$(VERSION).tar.xz
 	tar xf libpng-$(VERSION).tar.xz
 	cd libpng-$(VERSION) && ./configure --prefix=/usr/local --disable-static
 	cd libpng-$(VERSION) && $(MAKE)


### PR DESCRIPTION
The curl command downloaded an html redirect page instead of the content.

Looking at the diff it may be that it's not a stable url depending on where you're coming from. I'll submit this but maybe switching to a different tool which can follow the redirects would be better. 
